### PR TITLE
Support parameterized subdomain

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ Application ID and Secret. See the [Zendesk help page][1] for details.
 
 ## Usage
 
+#### Single Subdomain
+
 ```ruby
 use OmniAuth::Builder.do
   provider :zendesk, ENV['ZD_CLIENT'], ENV['ZD_SECRET'], client_options: {
@@ -15,4 +17,21 @@ end
 
 Scope can be either `read`, `write` or `read write`.
 
+#### Multiple Subdomains
+
+If you have [Global OAuth][2] enabled for Zendesk you can specify the
+**subdomain** in a URL parameter called `subdomain`. If you would like to do
+this do not specify a `site` in the builder because that will override the
+`subdomain` parameter.
+
+```ruby
+use OmniAuth::Builder.do
+  provider :zendesk, ENV['ZD_CLIENT'], ENV['ZD_SECRET'], scope: 'read'
+end
+```
+
+Then your Omniauth URL should be formulated like this:
+`https://mysite.local/auth/zendesk?subdomain=myzendesk`
+
 [1]: https://support.zendesk.com/hc/en-us/articles/203663836-Using-OAuth-authentication-with-your-application#topic_pvr_ncl_1l
+[2]: https://support.zendesk.com/hc/en-us/articles/203691386-Using-a-Global-OAuth-Client-to-Integrate-with-Zendesk

--- a/spec/omniauth/strategies/zendesk_spec.rb
+++ b/spec/omniauth/strategies/zendesk_spec.rb
@@ -5,19 +5,31 @@ describe OmniAuth::Strategies::Zendesk do
     OmniAuth::Strategies::Zendesk.new({})
   end
 
-  context 'client options' do
-    it 'should have correct site' do
-      site = subject.options.client_options.site
-      expect(site).to eq('https://test.zendesk.com')
+  context '#zendesk_url' do
+
+    it "defaults to the 'test' subdomain" do
+      allow(subject).to receive(:request).and_return(OpenStruct.new(params: {}))
+      allow(subject).to receive(:session).and_return({})
+      expect(subject.zendesk_url).to eq("https://test.zendesk.com")
     end
 
-    it 'should let client override site' do
-      strategy = OmniAuth::Strategies::Zendesk.new(
+    it "overrides the site with client_options" do
+      subject = OmniAuth::Strategies::Zendesk.new(
         'KEY', 'SECRET',
         client_options: { site: 'https://test2.zendesk.com' }
       )
-      site = strategy.options.client_options.site
-      expect(site).to eq('https://test2.zendesk.com')
+      allow(subject).to receive(:request).and_return(OpenStruct.new(params: {}))
+      allow(subject).to receive(:session).and_return({})
+      expect(subject.zendesk_url).to eq("https://test2.zendesk.com")
+    end
+
+    it "overrides the site with a request parameter" do
+      subject.options.client_options.site
+      allow(subject).to receive(:session).and_return({})
+      allow(subject).to receive(:request) do
+        double("Request", :params => {"subdomain" => "testsite"})
+      end
+      expect(subject.zendesk_url).to eq('https://testsite.zendesk.com')
     end
   end
 
@@ -46,4 +58,5 @@ describe OmniAuth::Strategies::Zendesk do
       it {expect(subject.info).to have_key 'organization_id'}
     end
   end
+
 end

--- a/spec/omniauth/strategies/zendesk_spec.rb
+++ b/spec/omniauth/strategies/zendesk_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'ostruct'
 
 describe OmniAuth::Strategies::Zendesk do
   subject do


### PR DESCRIPTION
This pull request adds support for multiple Zendesk subdomains when Global OAuth has been granted. Let me know if you see anything outstanding that you'd like changed.

Vielen Dank!

- Dan