### PR TITLE
Resolve issues resulting from omniauth2 updgrade

### DIFF
--- a/lib/omniauth/strategies/zendesk.rb
+++ b/lib/omniauth/strategies/zendesk.rb
@@ -19,6 +19,10 @@ module OmniAuth
         end
       end
 
+      def callback_url
+        options[:redirect_uri] || (full_host + script_name + callback_path)
+      end
+
       def raw_info
         @raw_info ||= access_token.get('/api/v2/users/me.json').parsed
       end


### PR DESCRIPTION
This allows the omniauth2 dependency on a specific version `1.3.1` to be removed.

https://github.com/intridea/omniauth-oauth2/issues/81#issuecomment-151281907
