### PR TITLE
Don't allow question marks or periods in Zendesk subdomain

### DIFF
--- a/lib/omniauth/strategies/zendesk.rb
+++ b/lib/omniauth/strategies/zendesk.rb
@@ -16,6 +16,25 @@ module OmniAuth
         super
       end
 
+      def request_phase
+        if invalid_subdomain?
+          fail!("Invalid subdomain, please ensure subdomain doesn't contain periods or question marks")
+        else
+          super
+        end
+      end
+
+      # Don't allow ? or . in subdomain, for security reasons. User could be
+      # redirected to attacker-controller domain if subdomain is something like
+      # "bishopfox.com?name=value"
+      def invalid_subdomain?
+        if request.params["subdomain"]
+          return true if request.params["subdomain"].include?("?")
+          return true if request.params["subdomain"].include?(".")
+        end
+        false
+      end
+
       def callback_phase
         zendesk_url # call it so it's memoized and we can ditch the session variable
         session.delete "subdomain"
@@ -69,7 +88,6 @@ module OmniAuth
       extra do
         { 'raw_info' => raw_info }
       end
-
     end
   end
 end

--- a/lib/omniauth/strategies/zendesk.rb
+++ b/lib/omniauth/strategies/zendesk.rb
@@ -45,6 +45,10 @@ module OmniAuth
         end
       end
 
+      def callback_url
+        options[:redirect_uri] || (full_host + script_name + callback_path)
+      end
+
       def raw_info
         @raw_info ||= access_token.get('/api/v2/users/me.json').parsed
       end


### PR DESCRIPTION
For security reasons, question marks and periods should not be present
in the Zendesk subdomain. If a subdomain value such as
"bishopfox.com?name=value" is passed, with the current redirect logic
we'd send the user to "https://bishopfox.com?name=value.zendesk.com",
which could be an attacker-controlled domain.

Note: This also includes @adambird's patch to support OmniAuth 2, which should be merged.

@jonasoberschweiber Any chance this stuff will get merged? My company (http://github.com/getcommande) can take over this repo if this is something you're not using anymore. Thanks for writing it in the first place, it saved us a lot of time.