### PR TITLE
Fix callback path

### DIFF
--- a/lib/omniauth/strategies/zendesk.rb
+++ b/lib/omniauth/strategies/zendesk.rb
@@ -45,6 +45,12 @@ module OmniAuth
         end
       end
 
+      def callback_url
+        # make sure the query string doesnt get added to the redirect_uri
+        # https://github.com/intridea/omniauth-oauth2/issues/93
+        full_host + script_name + callback_path
+      end
+
       def raw_info
         @raw_info ||= access_token.get('/api/v2/users/me.json').parsed
       end


### PR DESCRIPTION
We have seen this before and fixed in some of our other integrations: https://github.com/loyaltylion/hogwarts/pull/2258 this applies the same fix to our zendesk omniauth setup.

Essentially omniauth 2 changed how it calculates a callback url it now includes query params. We have some dynmaic ones (site_id) we can't set these in the whitelisted callback urls on the remote side so we can strip them here. See the linked PR for more details.